### PR TITLE
Feature/signup ssr

### DIFF
--- a/packages/hello-gsm/src/Api/auth.ts
+++ b/packages/hello-gsm/src/Api/auth.ts
@@ -56,6 +56,25 @@ class Auth {
       return error;
     }
   }
+
+  /**
+   *
+   * @param accessToken - api 요청을 하기 위한 토큰
+   * @returns - 로그인 여부 확인
+   */
+  check(accessToken?: string) {
+    try {
+      return RequestApi(
+        {
+          method: 'GET',
+          url: AuthController.check(),
+        },
+        accessToken,
+      );
+    } catch (error: any) {
+      return error;
+    }
+  }
 }
 
 export default new Auth();

--- a/packages/hello-gsm/src/Api/user.ts
+++ b/packages/hello-gsm/src/Api/user.ts
@@ -22,13 +22,16 @@ class User {
   /**
    * @returns 회원가입 시에 기입한 유저의 정보를 반환한다
    */
-  info() {
+  info(accessToken: string) {
     try {
-      return RequestApi({
-        method: 'GET',
-        url: UserController.info(),
-      });
-    } catch (error) {
+      return RequestApi(
+        {
+          method: 'GET',
+          url: UserController.info(),
+        },
+        accessToken,
+      );
+    } catch (error: any) {
       return error;
     }
   }

--- a/packages/hello-gsm/src/Utils/Libs/requestUrls.ts
+++ b/packages/hello-gsm/src/Utils/Libs/requestUrls.ts
@@ -12,6 +12,9 @@ export const AuthController = {
   refresh: () => {
     return `/auth/refresh`;
   },
+  check: () => {
+    return `/auth/check`;
+  },
 };
 
 // 유저 상태

--- a/packages/hello-gsm/src/components/SideBar/index.tsx
+++ b/packages/hello-gsm/src/components/SideBar/index.tsx
@@ -60,7 +60,6 @@ const SideBar: NextPage = () => {
           ) : (
             <S.Auth>
               <NavLink href="/auth/signin">로그인</NavLink>
-              <NavLink href="/auth/signup">회원가입</NavLink>
             </S.Auth>
           )}
         </S.NavSection>

--- a/packages/hello-gsm/src/pages/auth/signup.tsx
+++ b/packages/hello-gsm/src/pages/auth/signup.tsx
@@ -1,4 +1,4 @@
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import { SEOHelmet, SignUpPage } from 'components';
 
 const SignUp: NextPage = () => {
@@ -10,6 +10,21 @@ const SignUp: NextPage = () => {
       <SignUpPage />
     </>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async ctx => {
+  if (ctx.req.cookies.registerToken) {
+    return {
+      props: {},
+    };
+  } else {
+    return {
+      props: {},
+      redirect: {
+        destination: '/',
+      },
+    };
+  }
 };
 
 export default SignUp;

--- a/packages/hello-gsm/src/pages/auth/signup.tsx
+++ b/packages/hello-gsm/src/pages/auth/signup.tsx
@@ -12,19 +12,19 @@ const SignUp: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async ctx => {
-  if (ctx.req.cookies.registerToken) {
-    return {
-      props: {},
-    };
-  } else {
-    return {
-      props: {},
-      redirect: {
-        destination: '/',
-      },
-    };
-  }
-};
+// export const getServerSideProps: GetServerSideProps = async ctx => {
+//   if (ctx.req.cookies.registerToken) {
+//     return {
+//       props: {},
+//     };
+//   } else {
+//     return {
+//       props: {},
+//       redirect: {
+//         destination: '/',
+//       },
+//     };
+//   }
+// };
 
 export default SignUp;


### PR DESCRIPTION
## 개요 💡

> auth 페이지에서 ssr을 추가하려고 했습니다.

## 작업내용 ⌨️
- check api url, request 추가
- info api accessToken 추가
- sideBar 회원가입 접근 제거

auth 페이지에서 ssr을 추가하여 회원 구분을 하려고 하였으나
로그인한 상태에서 회원가입 요청을 해도 `registerToken`이 없기 때문에 굳이 막을 필요가 없고, 
로그인한 상태에서 다시 로그인페이지로 접근해도 크게 상관이 없기 때문에 ssr 작업은 안하였습니다.
