### PR TITLE
Mypage style 수정

### DIFF
--- a/packages/hello-gsm/src/PageContainer/MypagePage/style.ts
+++ b/packages/hello-gsm/src/PageContainer/MypagePage/style.ts
@@ -8,7 +8,7 @@ export const MyPage = styled.div`
 `;
 
 export const Content = styled.div`
-  height: 300px;
+  height: 270px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -18,7 +18,7 @@ export const Content = styled.div`
 `;
 
 export const UserBox = styled.div`
-  height: 200px;
+  height: 175px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## 개요 💡

> mypage의 디자인과 비일치했던 부분을 정확하게 변경했습니다

## 작업내용 ⌨️

<img width="315" alt="2022-06-27_8 17 19" src="https://user-images.githubusercontent.com/80103328/175930713-c23c0564-fdad-4071-835b-2c219e16dfea.png">

- mypage 프로필과 이름 사이 간격조절
- mypage 프로필 박스와 버튼 박스 사이 간격 조절