### PR TITLE
Hotfix/month

### DIFF
--- a/packages/hello-gsm/src/PageContainer/SignUpPage/index.tsx
+++ b/packages/hello-gsm/src/PageContainer/SignUpPage/index.tsx
@@ -116,6 +116,10 @@ const SignUpPage: NextPage = () => {
             type="text"
             {...register('name', {
               required: '* 성명을 입력해주세요.',
+              pattern: {
+                value: /^[ㄱ-ㅎ|가-힣]{2,5}$/,
+                message: '* 성명을 확인해주세요.',
+              },
             })}
           />
           <S.ErrorMessage css={errors.name && selectErrorStyle(255)}>
@@ -126,11 +130,11 @@ const SignUpPage: NextPage = () => {
             <S.Select
               {...register('year', {
                 validate: {
-                  notZero: value => value !== '0',
+                  notZero: value => value !== 'unSelected',
                 },
               })}
             >
-              <option value={'0'}>년</option>
+              <option value={'unSelected'}>년</option>
               {[...Array(10)].map((_, i) => (
                 <option value={`200${i}`} key={i}>
                   200{i}년
@@ -141,11 +145,11 @@ const SignUpPage: NextPage = () => {
             <S.Select
               {...register('month', {
                 validate: {
-                  notZero: value => value !== '0',
+                  notZero: value => value !== 'unSelected',
                 },
               })}
             >
-              <option value={'0'}>월</option>
+              <option value={'unSelected'}>월</option>
               {[...Array(12)].map((_, i) => (
                 <option value={`${i}`} key={i}>
                   {i + 1}월
@@ -156,11 +160,11 @@ const SignUpPage: NextPage = () => {
             <S.Select
               {...register('day', {
                 validate: {
-                  notZero: value => value !== '0',
+                  notZero: value => value !== 'unSelected',
                 },
               })}
             >
-              <option value={'0'}>일</option>
+              <option value={'unSelected'}>일</option>
               {[...Array(31)].map((_, i) => (
                 <option key={i} value={`${i + 1}`}>
                   {i + 1}일

--- a/packages/hello-gsm/src/PageContainer/SignUpPage/index.tsx
+++ b/packages/hello-gsm/src/PageContainer/SignUpPage/index.tsx
@@ -117,7 +117,7 @@ const SignUpPage: NextPage = () => {
             {...register('name', {
               required: '* 성명을 입력해주세요.',
               pattern: {
-                value: /^[ㄱ-ㅎ|가-힣]{2,5}$/,
+                value: /^[가-힣]{2,5}$/,
                 message: '* 성명을 확인해주세요.',
               },
             })}


### PR DESCRIPTION
## 개요 💡

회원가입에서 1월을 선택 시 에러가 나는 상황 해결

## 작업내용 ⌨️

1월의 value가 '0'이었는데 validate에서 값이 '0'이면 선택 안한 걸로 인식해서 에러가 났었음 
그래서 생년월일 전부다 '0'이랑 비교하는 것이 아닌 'unSelected'값이면 에러 나게 수정

- 이름 정규식 추가
- '0' -> 'unSelected'

## 관련 issue 🤯

https://github.com/themoment-team/hello-gsm-front/issues/99