### PR TITLE
Add file type filter

### DIFF
--- a/packages/hello-gsm/src/PageContainer/ApplyPage/index.tsx
+++ b/packages/hello-gsm/src/PageContainer/ApplyPage/index.tsx
@@ -172,6 +172,10 @@ const ApplyPage: NextPage<GetApplicationType> = ({ data }) => {
         toast.error('증명사진은 500KB 이하만 업로드 가능합니다.');
         return;
       }
+      if (!event.target.files[0].type.includes('image')) {
+        toast.error('이미지 파일만 업로드 가능합니다.');
+        return;
+      }
       // 파일의 url을 읽는다.
       event.target.files[0] && reader.readAsDataURL(event.target.files[0]);
     }


### PR DESCRIPTION
## 개요 💡

> 증명사진의 파일 타입이 이미지 형식이 아닌 경우 업로드 할 수 없도록 하였습니다

## 작업내용 ⌨️

> png일 경우 `image/png` 형식으로 반환되는 문자열에 image가 있는지 검사하여 없을 경우 이미지 업로드를 할 수 없도록 한다.