### PR TITLE
Update AnswerBody style

### DIFF
--- a/packages/hello-gsm/src/components/Modals/FAQModal/style.ts
+++ b/packages/hello-gsm/src/components/Modals/FAQModal/style.ts
@@ -165,6 +165,7 @@ export const AnswerBody = styled.div`
   line-height: 28px;
   text-align: center;
   color: #525252;
+  overflow-y: scroll;
   @media ${device.tablet} {
     font-size: 17px;
     height: 80%;


### PR DESCRIPTION
## 개요 💡

> faq 모달 반응형 수정

## 작업내용 ⌨️

> faq 모달에서 아래처럼 답변 내용이 많은 경우 간혹 답변 내용이 영역을 벗어나는 이슈가 존재하여 `overflow-y: scroll`로 유연하게 대응하였습니다

**before**
<img width="300" alt="before" src="https://user-images.githubusercontent.com/80103328/192000974-b3286fc2-a69f-4106-a7a7-52dee01ca5a1.png">

**after**
<img width="300" alt="after" src="https://user-images.githubusercontent.com/80103328/192001836-35e67cd4-cfb7-48bf-9a5b-e023a4ea6995.gif">