### PR TITLE
학교 찾기 모달 반응형 스타일 추가

### DIFF
--- a/packages/hello-gsm/src/components/Modals/FindSchoolModal/index.tsx
+++ b/packages/hello-gsm/src/components/Modals/FindSchoolModal/index.tsx
@@ -35,12 +35,6 @@ const FindSchoolModal: React.FC = () => {
     }
   };
 
-  const enterEvent = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      search();
-    }
-  };
-
   useEffect(() => {
     keyword && getSchools();
   }, [keyword]);
@@ -68,6 +62,12 @@ const FindSchoolModal: React.FC = () => {
     setShowFindSchoolModal();
   };
 
+  const enterEvent = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      search();
+    }
+  };
+
   const removeClick = useCallback((e: MouseEvent<HTMLDivElement>): void => {
     e.stopPropagation();
   }, []);
@@ -77,7 +77,7 @@ const FindSchoolModal: React.FC = () => {
       <Global
         styles={css`
           body {
-            overflow: ${showFindSchoolModal ? 'hidden' : 'visible'};
+            overflow: ${showFindSchoolModal ? 'scroll' : 'visible'};
           }
         `}
       />

--- a/packages/hello-gsm/src/components/Modals/FindSchoolModal/index.tsx
+++ b/packages/hello-gsm/src/components/Modals/FindSchoolModal/index.tsx
@@ -77,7 +77,7 @@ const FindSchoolModal: React.FC = () => {
       <Global
         styles={css`
           body {
-            overflow: ${showFindSchoolModal ? 'scroll' : 'visible'};
+            overflow: ${showFindSchoolModal ? 'hidden' : 'visible'};
           }
         `}
       />

--- a/packages/hello-gsm/src/components/Modals/FindSchoolModal/style.ts
+++ b/packages/hello-gsm/src/components/Modals/FindSchoolModal/style.ts
@@ -9,6 +9,10 @@ export const FindSchoolModal = styled.div`
   align-items: center;
   position: fixed;
   z-index: 5;
+  overflow: scroll;
+  @media (max-height: 830px) {
+    display: block;
+  }
 `;
 
 export const FindSchoolModalBox = styled.div`
@@ -20,6 +24,9 @@ export const FindSchoolModalBox = styled.div`
   flex-direction: column;
   padding-top: 50px;
   align-items: center;
+  @media (max-height: 830px) {
+    margin: 0 auto;
+  }
 `;
 
 export const CancelButton = styled.div`


### PR DESCRIPTION
## 개요 💡

> FindSchoolModal 반응형 스타일 추가

## 작업내용 ⌨️

> 모달 height 보다 뷰 포트의 height가 작을 시 스크롤로 모달 컨텐츠를 유연하게 스타일링 하였습니다.
> pc에서만 원서 접수가 가능하므로 모달의 height(830px)가 평균 pc 디스플레이 사이즈 (1920 x 1080)보다 작아 반응형 이슈가 빈번하지 않을 것 이라고 생각되어 이 처럼 스타일링 하였습니다.