### PR TITLE
주소 찾기 모달 반응형 스타일링

### DIFF
--- a/packages/hello-gsm/src/components/Modals/FindAddressModal/style.ts
+++ b/packages/hello-gsm/src/components/Modals/FindAddressModal/style.ts
@@ -9,4 +9,8 @@ export const FindAddressModal = styled.div`
   align-items: center;
   position: fixed;
   z-index: 5;
+  @media (max-height: 500px) {
+    overflow: scroll;
+    align-items: flex-start;
+  }
 `;


### PR DESCRIPTION
## 개요 💡

> 주소 찾기 모달의 반응형 스타일링을 추가했습니다

## 작업내용 ⌨️

> 뷰포트 height가 주소찾기 모달의 height(500px) 이하일 시, 스크롤로 모달을 확인할 수 있도록 스타일링 했습니다
> 원서 접수가 pc에서만 가능하므로, pc 평균 디스플레이 사이즈(1920x1080)를 생각하면 반응형 이슈가 빈번하지 않을 것 같아 이와 같이 스타일링했습니다