### PR TITLE
Update mobile style

### DIFF
--- a/packages/hello-gsm/src/components/BubbleButton/style.ts
+++ b/packages/hello-gsm/src/components/BubbleButton/style.ts
@@ -55,19 +55,6 @@ export const ToCalculator = styled.button`
   }
 
   @media ${device.mobile} {
-    position: static;
-    font-size: 14px;
-    width: 240px;
-    height: 40px;
-    &:nth-of-type(1) {
-      line-height: 20px;
-      padding: 0 20px;
-    }
-    &:nth-of-type(2) {
-      line-height: 20px;
-    }
-    :after {
-      display: none;
-    }
+    display: none;
   }
 `;


### PR DESCRIPTION
## 개요 💡

> 모바일에서 말풍선 컴포넌트를 안보이게 하였습니다.

## 작업내용 ⌨️

- 메인페이지에서 모바일 사이즈가 됐을 때`여러 계정으로 로그인 하는 법`, `모의 성적 계산 해보기` 버튼이 안보이게 하였습니다.
