### PR TITLE
[Hotfix] admin finalResult

### DIFF
--- a/packages/hello-gsm-admin/src/Stores/StoreContainer.ts
+++ b/packages/hello-gsm-admin/src/Stores/StoreContainer.ts
@@ -9,7 +9,7 @@ interface StoreType {
   setShowScoreModal: () => void;
   setModalRegistrationNumber: (registrationNumber: number) => void;
   setModalName: (name: string) => void;
-  setScoreModalValue: (value: number) => void;
+  setScoreModalValue: (value: number | null) => void;
 }
 
 const useStore = create<StoreType>(set => ({

--- a/packages/hello-gsm-admin/src/components/ContentBox/index.tsx
+++ b/packages/hello-gsm-admin/src/components/ContentBox/index.tsx
@@ -136,7 +136,7 @@ const ContentBox: React.FC<ContentType> = ({
     setModalRegistrationNumber(registrationNumber);
     setModalName(name);
     setShowScoreModal();
-    setScoreModalValue(score ?? 0);
+    setScoreModalValue(score);
   };
 
   return (


### PR DESCRIPTION
## 개요 💡

> admin 2차 점수가 없는 학생의 2차 점수 입력 취소 시 0점으로 표기되는 현상 수정

## 작업내용 ⌨️

> 기존에 값이 null일 시 `setScoreModalValue`에 0을 넘겨주는 코드를 제거했습니다