### PR TITLE
[Update] fix ged calculator nan error

### DIFF
--- a/packages/hello-gsm/src/PageContainer/GEDCalculatorPage/index.tsx
+++ b/packages/hello-gsm/src/PageContainer/GEDCalculatorPage/index.tsx
@@ -57,7 +57,8 @@ const GEDCalculatorPage: NextPage<GEDCalculatorPageProps> = ({
       nonCurriculumScoreSubtotal,
     );
 
-    const scoreTotal = Rounds((300 - (300 * rankPercentage) / 100) * 0.87, 3);
+    const scoreTotal =
+      rankPercentage && Rounds((300 - (300 * rankPercentage) / 100) * 0.87, 3);
 
     try {
       await TrySubmission({

--- a/packages/hello-gsm/src/PageContainer/Test/GEDCalculatorPage/index.tsx
+++ b/packages/hello-gsm/src/PageContainer/Test/GEDCalculatorPage/index.tsx
@@ -28,7 +28,8 @@ const TestGEDCalculatorPage: NextPage = () => {
       curriculumScoreSubtotal,
       nonCurriculumScoreSubtotal,
     );
-    const scoreTotal = Rounds((300 - (300 * rankPercentage) / 100) * 0.87, 3);
+    const scoreTotal =
+      rankPercentage && Rounds((300 - (300 * rankPercentage) / 100) * 0.87, 3);
 
     setResultNumber([rankPercentage, scoreTotal]);
     setShowScoreResult();

--- a/packages/hello-gsm/src/Utils/Calculate/GEDCalculate.ts
+++ b/packages/hello-gsm/src/Utils/Calculate/GEDCalculate.ts
@@ -1,7 +1,7 @@
 import { Rounds } from 'Utils/Calculate';
 
 const GEDCalculate = (score: number, perfectScore: number) => {
-  return Rounds((1 - score / perfectScore) * 100, 3);
+  return score && perfectScore && Rounds((1 - score / perfectScore) * 100, 3);
 };
 
 export default GEDCalculate;


### PR DESCRIPTION
## 개요 💡

검정고시 성적 계산시 0을 입력시 NaN이뜨는 문제를 해결하였습니다.

## 작업내용 ⌨️

87a511b , 4f9ef95 , ac9df58 에서 확인가능합니다.

- Before
![스크린샷 2023-08-30 오후 8 55 08](https://github.com/themoment-team/hello-gsm-front/assets/103944346/1c70d4b1-c4d5-420a-9ec5-5ee019c63690)

- After 
<img width="1149" alt="스크린샷 2023-08-30 오후 10 32 50" src="https://github.com/themoment-team/hello-gsm-front/assets/103944346/58d933fa-4a7d-4a81-ac96-8dff06a5c8d8">

숫자 넣어서 테스트 해주시면 감사하겠습니다